### PR TITLE
Fix broken contact email links across site pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 			</div>
 			<div class="row contact-methods">
 				<div class="col-12 text-center">
-					<a href="mailTo:sambfreund@gmail.com" class="contactButton">sambfreund@gmail.com</a>
+					<a href="mailto:sambfreund@gmail.com" class="contactButton">sambfreund@gmail.com</a>
 				</div>
 			</div>
 			<div class="row social-links">

--- a/mutowuto.html
+++ b/mutowuto.html
@@ -191,7 +191,7 @@
 				<div class="col-12 text-center">
 					<h2>Let's chat!</h2>
 					<p class="subHeading">If you'd like to get in contact feel free to drop me an e-mail here.</p>
-					<a href="mailTo:sambfreund@gmail.com" class="contactButton">sambfreund@gmail.com</a>
+					<a href="mailto:sambfreund@gmail.com" class="contactButton">sambfreund@gmail.com</a>
 				</div>
 			</div>
 		</div>

--- a/prioritymaker.html
+++ b/prioritymaker.html
@@ -111,7 +111,7 @@
 				<div class="col-12 text-center">
 					<h2>Let's chat!</h2>
 					<p class="subHeading">If you'd like to get in contact feel free to drop me an e-mail here.</p>
-					<a href="mailTo:sambfreund@gmail.com" class="contactButton">sambfreund@gmail.com</a>
+					<a href="mailto:sambfreund@gmail.com" class="contactButton">sambfreund@gmail.com</a>
 				</div>
 			</div>
 		</div>

--- a/recommendations.html
+++ b/recommendations.html
@@ -163,7 +163,7 @@
 		<div class="col-md-12 text-center">
 			<h2>Let's chat!</h2>
       <p class="subHeading">If you'd like to get in contact feel free to drop me an e-mail here.</p>
-			<a href="mailTo:sambfreund@gmail.com" class="contactButton-blog">Email</a>
+			<a href="mailto:sambfreund@gmail.com" class="contactButton-blog">Email</a>
 		</div>
 	</div>
 


### PR DESCRIPTION
### Motivation
- Correct malformed contact anchors using `mailTo:` which prevented clicking the links from reliably opening the user's email client.

### Description
- Replaced `mailTo:` with the correct `mailto:` scheme in `index.html`, `prioritymaker.html`, `mutowuto.html`, and `recommendations.html` so contact links function properly.

### Testing
- Verified the fix with a repository-wide search using `rg -n "mailTo:|mailto:" *.html` and confirmed only `mailto:` occurrences remain, indicating the replacements succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf6fa1280832a9c6599b3fdcf65aa)